### PR TITLE
Opening the webbrowser using the webbrowser module

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,6 @@ After that, fetch & use a "bare" release:
 python3 server.py
 ```
 
-Currently the web browser will not open automatically in MacOS. Please run manually and go to `http://127.0.0.1:8095`, or just click [here](http://127.0.0.1:8095).
-
 ### Worth to Note
 
 For all supported platforms,  

--- a/readme.i18n/README.de_DE.md
+++ b/readme.i18n/README.de_DE.md
@@ -76,9 +76,6 @@ Laden Sie sich die "reine (pure)" Version herunter und führen Sie dieselben Sch
 python3 server.py
 ```
 
-Auf dem Mac öffnet sich der Browser derzeit nicht automatisch. Bitte starten Sie einen Browser manuell und navigieren Sie zu `http://127.0.0.1:8095`. 
-
-Alternativ können Sie auch folgenden Link verwenden: [Link](http://127.0.0.1:8095)
 
 
 ### Anmerkung

--- a/readme.i18n/README.zh_CN.md
+++ b/readme.i18n/README.zh_CN.md
@@ -95,9 +95,6 @@ pip3 install pyobjc bleak
 python3 server.py
 ```
 
-当前在 MacOS 浏览器不会自动打开。您可以手动访问 `http://127.0.0.1:8095`，或点击[这里](http://127.0.0.1:8095)
-
-
 ### 值得注意
 
 对于所有支持的平台，  

--- a/server.py
+++ b/server.py
@@ -12,8 +12,8 @@ import os
 import io
 import sys
 import json
-import platform
 import warnings
+import webbrowser
 
 # For now we can't use `ThreadingHTTPServer`
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -339,18 +339,11 @@ def serve():
         listen_all = True
     server = PrinterServer(('' if listen_all else address, port), PrinterServerHandler)
     service_url = f'http://{address}:{port}/'
-    if '-s' in sys.argv:
-        info(i18n('serving-at-0', service_url))
-    else:
-        operating_system = platform.uname().system
-        if operating_system == 'Windows':
-            os.system(f'start {service_url} > NUL')
-        elif operating_system == 'Linux':
-            os.system(f'xdg-open {service_url} &> /dev/null')
-        # TODO: I don't know about macOS
-        # elif operating_system == 'macOS':
-        else:
-            info(i18n('serving-at-0', service_url))
+    
+    info(i18n('serving-at-0', service_url))
+    if '-s' not in sys.argv:
+        webbrowser.open(service_url)
+    
     try:
         server.serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
Replaced the call to `os.system` with python's built in "webbrowser" module.

This change adds support for opening the web interface on MacOS.