### PR TITLE
Add Bluetooth permission request for Android 12+

### DIFF
--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ warnings.simplefilter('ignore', RuntimeWarning, 0, True)
 
 IsAndroid = (os.environ.get("P4A_BOOTSTRAP") is not None)
 
+
 class DictAsObject(dict):
     """ Let you use a dict like an object in JavaScript.
     """
@@ -341,9 +342,14 @@ def serve():
     server = PrinterServer(('' if listen_all else address, port), PrinterServerHandler)
     service_url = f'http://{address}:{port}/'
     
+
     info(i18n('serving-at-0', service_url))
-    if '-s' not in sys.argv:
+    if '-s' not in sys.argv and not IsAndroid:
         webbrowser.open(service_url)
+    # Request required bluetooth permissions (Android 12+)
+    if IsAndroid:
+        from android.permissions import request_permissions, Permission
+        request_permissions([Permission.BLUETOOTH_SCAN, Permission.BLUETOOTH_CONNECT])
     
     try:
         server.serve_forever()


### PR DESCRIPTION
This PR adds a permission request for `BLUETOOTH_SCAN` and `BLUETOOTH_CONNECT`.
This permission request is required to scan for devices on Android 12 or higher.

Fixes #41
![Screenshot_20230210-152628](https://user-images.githubusercontent.com/17365446/218116263-1ad0930c-a955-491a-909f-0cc434e4f013.png)
